### PR TITLE
Improve AI JSON parsing in CONAMEI generator

### DIFF
--- a/web-conamei-maestra.html
+++ b/web-conamei-maestra.html
@@ -525,6 +525,22 @@
             return data.candidates[0].content.parts[0].text.replace(/^```json\s*|```\s*$/g, '').trim();
         }
 
+        // Parse JSON from AI responses more robustly, removing extra text and trailing commas
+        function parseAIJSON(text) {
+            const start = text.indexOf('{');
+            const end = text.lastIndexOf('}');
+            if (start === -1 || end === -1) {
+                throw new Error('La respuesta no contiene un JSON válido.');
+            }
+            const jsonStr = text.slice(start, end + 1);
+            try {
+                return JSON.parse(jsonStr);
+            } catch (e) {
+                const sanitized = jsonStr.replace(/,\s*(\}|\])/g, '$1');
+                return JSON.parse(sanitized);
+            }
+        }
+
         async function handleGatherData() {
             appState.dci = dciInput.value.trim();
             appState.indication = indicationInput.value.trim();
@@ -539,7 +555,7 @@
             try {
                 const searcherPrompt = buildSearcherPrompt(appState.dci, appState.indication);
                 const evidenceText = await runAIFetch(searcherPrompt);
-                appState.evidence = JSON.parse(evidenceText);
+                appState.evidence = parseAIJSON(evidenceText);
 
                 showStatus('Paso 1 completado. Evidencia recopilada. Listo para generar conclusión.');
                 updateUIForStep('gathering_done');
@@ -558,7 +574,7 @@
             try {
                 const evaluatorPrompt = buildEvaluatorPrompt(appState.evidence);
                 const evaluationText = await runAIFetch(evaluatorPrompt);
-                appState.evaluation = JSON.parse(evaluationText);
+                appState.evaluation = parseAIJSON(evaluationText);
 
                 showStatus('Paso 2 completado. Conclusión generada. Listo para ensamblar informe.');
                 updateUIForStep('conclusion_done');


### PR DESCRIPTION
## Summary
- Parse JSON responses from Google AI more robustly, stripping extra text and trailing commas
- Replace direct `JSON.parse` calls with `parseAIJSON` in data gathering and evaluation steps

## Testing
- `node - <<'NODE'
function parseAIJSON(text) {
  const start = text.indexOf('{');
  const end = text.lastIndexOf('}');
  if (start === -1 || end === -1) throw new Error('no json');
  const jsonStr = text.slice(start, end + 1);
  try { return JSON.parse(jsonStr); }
  catch(e) { const sanitized = jsonStr.replace(/,\s*(\}|\])/g,'$1'); return JSON.parse(sanitized); }
}
console.log(parseAIJSON('Here is JSON\n{"a":[1,2,],"b":3,}\nend'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689e1caa1fc4832eadf3c762944ebf87